### PR TITLE
Update Client initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Optional Properties for `createEventGatewayClient`
   // defaults to 80
   port: '8080', 
   // by default 'https' but we also support 'http'
-  protocol: 
+  protocol: 'http'
   // defaults to the default Gateway configuration port
   configurationPort: '3001'
   // optional property allowing the developer to provide their own http lib

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Optional Properties for `createEventGatewayClient`
 
 ```js
 {
-  // defaults to 80
+  // defaults to the default Gateway configuration port
   port: '8080', 
   // by default 'https' but we also support 'http'
   protocol: 'http'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ```js
 const fdk = require('fdk');
 const gateway = fdk.createEventGatewayClient({
-  host: 'localhost:3000'
+  hostname: 'localhost',
 })
 ```
 
@@ -18,7 +18,7 @@ ES2015
 ```js
 import { createEventGatewayClient } from 'fdk';
 const gateway = createEventGatewayClient({
-  host: 'localhost:3000'
+  hostname: 'localhost',
 })
 ```
 
@@ -26,6 +26,12 @@ Optional Properties for `createEventGatewayClient`
 
 ```js
 {
+  // defaults to 80
+  port: '8080', 
+  // by default 'https' but we also support 'http'
+  protocol: 
+  // defaults to the default Gateway configuration port
+  configurationPort: '3001'
   // optional property allowing the developer to provide their own http lib
   // ideal for mocking or to cover edge cases like passing in special headers
   fetchClient: fetch


### PR DESCRIPTION
With the new API I was thinking about either to split the client into two. One for configuration, one for the exposed HTTP API + Invoke + Emit.

After all I suggest we opt in for splitting `host` into `hostname`, `port` and & `configurationPort`. Ideally people will never need to provide port, nor protocol nor configurationPort as it has default values that are used by the Gateway itself. Our framework has to use `protocol` to make sure to use `http` for talking to the API. For production usage we highly recommend HTTPS and therefor thats the default.