### PR TITLE
Command for repeatable execution

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const listFunctions = require('./listFunctions')
+const listSubscriptions = require('./listSubscriptions')
+const deleteFunction = require('./deleteFunction')
+const unsubscribe = require('./unsubscribe')
+const configure = require('./configure')
+const without = require('ramda/src/without')
+
+/*
+ * Configures the Event Gateway as given in params.
+ */
+module.exports = (config, params) => {
+  const updatedParams = { functions: [], subscriptions: [] }
+
+  return listSubscriptions(config)
+  .then(existing => {
+    const removed = without(params.subscriptions, existing.subscriptions)
+    const added = without(existing.subscriptions, params.subscriptions)
+
+    updatedParams.subscriptions = added
+
+    return Promise.all(removed.map(subscription =>
+      unsubscribe(config, { subscriptionId: subscription.subscriptionId })
+    ))
+    .catch(subscriptionError => {
+      throw new Error(`Failed to delete subscriptions. ${subscriptionError.message}`)
+    })
+  })
+  .then(() => listFunctions(config))
+  .then(existing => {
+    const removed = without(params.functions, existing.functions)
+    const added = without(existing.functions, params.functions)
+
+    updatedParams.functions = added
+
+    return Promise.all(removed.map(
+        func => deleteFunction(config, { functionId: func.functionId })
+    ))
+    .catch(funcError => {
+      throw new Error(`Failed to delete functions. ${funcError.message}`)
+    })
+  })
+  .then(() => configure(config, updatedParams))
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const subscribe = require('./subscribe')
 const unsubscribe = require('./unsubscribe')
 const listSubscriptions = require('./listSubscriptions')
 const configure = require('./configure')
+const deploy = require('./deploy')
 const resetConfiguration = require('./resetConfiguration')
 const emit = require('./emit')
 const invoke = require('./invoke')
@@ -35,6 +36,7 @@ const eventGateway = configuration => {
     emit: params => emit(config, params),
     invoke: params => invoke(config, params),
     configure: params => configure(config, params),
+    deploy: params => deploy(config, params),
     resetConfiguration: params => resetConfiguration(config, params),
     registerFunction: params => registerFunction(config, params),
     deleteFunction: params => deleteFunction(config, params),

--- a/tests/__snapshots__/deploy-subscriptions-fail.test.js.snap
+++ b/tests/__snapshots__/deploy-subscriptions-fail.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should fail to create multiple misconfigured subscriptions 1`] = `[Error: Failed to configure the Event Gateway. Failed to configure the Event Gateway. Failed to subscribe the event pageVisited to the function myFunctionTwo due the error: Function "myFunctionTwo" not found.]`;

--- a/tests/__snapshots__/deploy.test.js.snap
+++ b/tests/__snapshots__/deploy.test.js.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should created multiple functions and subscriptions if there are none 1`] = `
+Object {
+  "functions": Array [
+    Object {
+      "functionId": "myFunctionOne",
+      "provider": Object {
+        "arn": "https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/dev/test",
+        "region": "us-east-1",
+        "type": "awslambda",
+      },
+    },
+    Object {
+      "functionId": "myFunctionTwo",
+      "provider": Object {
+        "type": "http",
+        "url": "http://www.example.com",
+      },
+    },
+  ],
+  "subscriptions": Array [
+    Object {
+      "event": "pageVisited",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "pageVisited-myFunctionOne",
+    },
+    Object {
+      "event": "userCreated",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "userCreated-myFunctionOne",
+    },
+  ],
+}
+`;
+
+exports[`step1 1`] = `
+Object {
+  "functions": Array [],
+  "subscriptions": Array [
+    Object {
+      "event": "pageVisited",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "pageVisited-myFunctionOne",
+    },
+    Object {
+      "event": "userCreated",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "userCreated-myFunctionOne",
+    },
+  ],
+}
+`;
+
+exports[`step1 2`] = `
+Object {
+  "functions": Array [],
+  "subscriptions": Array [
+    Object {
+      "event": "pageVisited",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "pageVisited-myFunctionOne",
+    },
+    Object {
+      "event": "userCreated",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "userCreated-myFunctionOne",
+    },
+  ],
+}
+`;
+
+exports[`step2 1`] = `
+Object {
+  "functions": Array [
+    Object {
+      "functionId": "myFunctionThree",
+      "provider": Object {
+        "type": "http",
+        "url": "http://www.google.com",
+      },
+    },
+  ],
+  "subscriptions": Array [
+    Object {
+      "event": "pageVisited",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "pageVisited-myFunctionOne",
+    },
+    Object {
+      "event": "userCreated",
+      "functionId": "myFunctionOne",
+      "subscriptionId": "userCreated-myFunctionOne",
+    },
+    Object {
+      "event": "userDeleted",
+      "functionId": "myFunctionTwo",
+      "subscriptionId": "userDeleted-myFunctionTwo",
+    },
+    Object {
+      "event": "userUpdated",
+      "functionId": "myFunctionThree",
+      "subscriptionId": "userUpdated-myFunctionThree",
+    },
+  ],
+}
+`;
+
+exports[`step3 1`] = `
+Object {
+  "functions": Array [],
+  "subscriptions": Array [],
+}
+`;

--- a/tests/deploy-subscriptions-fail.test.js
+++ b/tests/deploy-subscriptions-fail.test.js
@@ -1,0 +1,48 @@
+const fdk = require('../lib/index')
+const eventGatewayProcesses = require('./event-gateway/processes')
+
+const config = {
+  functions: [
+    {
+      functionId: 'myFunctionOne',
+      provider: {
+        type: 'awslambda',
+        arn: 'https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/dev/test',
+        region: 'us-east-1',
+      },
+    },
+  ],
+  subscriptions: [
+    { functionId: 'myFunctionOne', event: 'pageVisited' },
+    { functionId: 'myFunctionTwo', event: 'pageVisited' },
+  ],
+}
+
+let eventGateway
+let eventGatewayProcessId
+
+beforeAll(() =>
+  eventGatewayProcesses
+    .spawn({
+      configPort: 4025,
+      apiPort: 4026,
+    })
+    .then(processInfo => {
+      eventGatewayProcessId = processInfo.id
+      eventGateway = fdk.eventGateway({
+        url: `http://localhost:${processInfo.apiPort}`,
+        configurationUrl: `http://localhost:${processInfo.configPort}`,
+      })
+    })
+)
+
+afterAll(() => {
+  eventGatewayProcesses.shutDown(eventGatewayProcessId)
+})
+
+test('should fail to create multiple misconfigured subscriptions', () => {
+  expect.assertions(1)
+  return eventGateway.deploy(config).catch(err => {
+    expect(err).toMatchSnapshot()
+  })
+})

--- a/tests/deploy.test.js
+++ b/tests/deploy.test.js
@@ -1,0 +1,111 @@
+const fdk = require('../lib/index')
+const eventGatewayProcesses = require('./event-gateway/processes')
+
+const step1 = {
+  functions: [
+    {
+      functionId: 'myFunctionOne',
+      provider: {
+        type: 'awslambda',
+        arn: 'https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/dev/test',
+        region: 'us-east-1',
+      },
+    },
+    {
+      functionId: 'myFunctionTwo',
+      provider: {
+        type: 'http',
+        url: 'http://www.example.com',
+      },
+    },
+  ],
+  subscriptions: [
+    { functionId: 'myFunctionOne', event: 'pageVisited' },
+    { functionId: 'myFunctionOne', event: 'userCreated' },
+  ],
+}
+
+const step2 = {
+  functions: [
+    {
+      functionId: 'myFunctionOne',
+      provider: {
+        type: 'awslambda',
+        arn: 'https://xxxxxxxxxx.execute-api.us-east-1.amazonaws.com/dev/test',
+        region: 'us-east-1',
+      },
+    },
+    {
+      functionId: 'myFunctionTwo',
+      provider: {
+        type: 'http',
+        url: 'http://www.example.com',
+      },
+    },
+    {
+      functionId: 'myFunctionThree',
+      provider: {
+        type: 'http',
+        url: 'http://www.google.com',
+      },
+    },
+  ],
+  subscriptions: [
+    { functionId: 'myFunctionOne', event: 'pageVisited' },
+    { functionId: 'myFunctionOne', event: 'userCreated' },
+    { functionId: 'myFunctionTwo', event: 'userDeleted' },
+    { functionId: 'myFunctionThree', event: 'userUpdated' },
+  ],
+}
+
+const step3 = {
+  functions: [],
+  subscriptions: [],
+}
+
+let eventGateway
+let eventGatewayProcessId
+
+beforeAll(() =>
+  eventGatewayProcesses
+    .spawn({
+      configPort: 4017,
+      apiPort: 4018,
+    })
+    .then(processInfo => {
+      eventGatewayProcessId = processInfo.id
+      eventGateway = fdk.eventGateway({
+        url: `http://localhost:${processInfo.apiPort}`,
+        configurationUrl: `http://localhost:${processInfo.configPort}`,
+      })
+    })
+)
+
+afterAll(() => {
+  eventGatewayProcesses.shutDown(eventGatewayProcessId)
+})
+
+test('should created multiple functions and subscriptions if there are none', () => {
+  expect.assertions(1)
+  return eventGateway
+    .deploy(step1)
+    .then(response => { expect(response).toMatchSnapshot() })
+})
+
+test('should create added functions and subscriptions', () => {
+  expect.assertions(2)
+  return eventGateway
+    .deploy(step1)
+    .then(response => { expect(response).toMatchSnapshot('step1') })
+    .then(() => eventGateway.deploy(step2))
+    .then(response => { expect(response).toMatchSnapshot('step2') })
+})
+
+test('should delete functions and subscriptions', () => {
+  expect.assertions(2)
+  return eventGateway
+    .deploy(step1)
+    .then(response => { expect(response).toMatchSnapshot('step1') })
+    .then(() => eventGateway.deploy(step3))
+    .then(response => { expect(response).toMatchSnapshot('step3') })
+})


### PR DESCRIPTION
Hey! Thanks for your awesome project. During the Event Gateway Workshop at JeffConf Hamburg on Thursday @pmuens introduced us to this project and we were wondering why the `configure` command will fail when run with the same configuration multiple times.

By looking at the code I figured that the `configure` command actually only adds functions and subscriptions and even tries to add the given functions/subscriptions if they already exist.

If Event Gateway would be used in a CI/CD scenario I think it would be very nice to have a command that can be executed at any time (multiple times) and just ensures that the configuration of the Event Gateway is set up as given. This way the actual configuration can be saved to a git repository and a build tool/service can just execute the given configuration on every build.

So I tried to introduce a `deploy` command (naming is hard, sorry. I choose `deploy` because it is used at serverless and basically has the same behaviour: only apply changes) and some tests.

As I wanted to hear what the maintainers and users of fdk / Event Gateway think about this, I'll create this pull-request without documentation/... changes.

Let me know what you think!